### PR TITLE
Arrow keys do not always work - issue #13

### DIFF
--- a/Parnassus.FMXContainer.pas
+++ b/Parnassus.FMXContainer.pas
@@ -729,6 +729,15 @@ begin
     // Call again to remove any duplicate
     PeekMessage(Msg, 0, WM_CHAR, WM_CHAR, PM_REMOVE);
     FFMXForm.KeyDown(Key, KeyChar, Shift);
+  end
+  else if not (Message.CharCode in [VK_SHIFT, VK_CONTROL]) then  //Shift and Control are handled by KeyDataToShiftState
+  begin
+    // In some circumstances non-character keycodes go directly to the FMX form (for instance after clicking the
+    // form). In other circumstances we land will land here.
+    // Without the following handling the KeyCodes are lost (eg. arrow keys, function keys etc. wont work)
+    Key := Message.CharCode;
+    KeyChar := #0;
+    FFMXForm.KeyDown(Key, KeyChar, Shift);
   end;
 end;
 


### PR DESCRIPTION
In some special circumstances the arrow keys (and other non-characte-keys) will not work. This is because sometimes the key message goes directly to the FMX form (=working) and sometimes it goes to the FiremonkeyContainer.

With this fix non-character-key-messages are retargeted to the FMX form.